### PR TITLE
New-updates

### DIFF
--- a/src/pages/tours/[slug]/index.tsx
+++ b/src/pages/tours/[slug]/index.tsx
@@ -110,9 +110,9 @@ export default function Page(props: PageProps) {
     return (
         <>
             <HeadSEO
-                title={`${title} | Tazama Africa Safaris`}
+                title={`Tazama Africa Safaris | ${title}`}
                 keywords={base_keywords}
-                description={subHeading || "Tazama Africa Safaris tour itinerary"}
+                description={subHeading || title}
             />
 
             {/* Dynamic hero header */}


### PR DESCRIPTION
The SEO description now defaults to the tour title when not provided, which is more relevant than using the subHeading as a fallback